### PR TITLE
Fixed TypeError when parsing schemas

### DIFF
--- a/lib/methods.js
+++ b/lib/methods.js
@@ -107,7 +107,22 @@ var getParametersForMethod = function(method, relativeUri) {
  * @param {Object} ramlResource - THe RAML resource to check
  */
 var isCollection = function(ramlResource) {
-  return (ramlResource.type || '').toLowerCase() == 'collection';
+
+  if (ramlResource.type) {
+    // Iterate through the type object and check if any of the keys contains
+    // the word collection.
+    for (var key in ramlResource.type) {
+      if (key && key.toLowerCase && key.toLowerCase().indexOf('collection') > 0) {
+        return true;
+      }
+    }
+  }
+
+  if (!ramlResource.type || !ramlResource.type.toLowerCase) {
+    return false;
+  }
+
+  return ramlResource.type.toLowerCase() == 'collection';
 };
 
 /**


### PR DESCRIPTION
This will fix an issue when using Schemas in RAML:

So for instance you have the following raml file:

``` yaml
#%RAML 0.8
title: Sample API
version: v1
baseUri: http://localhost:8888/api/{version}

schemas:
  - sample_entity: |
      {  "$schema": "http://json-schema.org/draft-03/schema",
         "type": "object",
         "description": "A single sample entity",
         "properties": {
           "id":  { "type": "integer", "required": true },
           "name":  { "type": "string", "required": true }
         }
      }

resourceTypes:
  - base:
      get?:
        responses: &standardResponses
          200:
            description: OK
  - member:
      type: base
      get:
  - typedMember:
      type: member
      get:
        responses:
          200:
            body:
              application/json:
                schema: <<schema>>

/sample_entity: &sample_entity
  /{id}:
    type: { typedMember: { schema: sample_entity } }
    uriParameters:
      id:
        type: integer
        description: ID of the sample entity
    get:
      description: Retrieve the specified sample entity
```

The generator will incorrectly handle schemas and will attempt to do a lower case on it which does not exist. You get the following error:

``` sh
return (ramlResource.type || '').toLowerCase() == 'collection';
                                   ^
TypeError: Object #<Object> has no method 'toLowerCase'
    at isCollection (/node_modules/generator-ramlang/lib/methods.js:110:36)
    at /node_modules/generator-ramlang/lib/methods.js:191:19
    at Array.forEach (native)
    at recursResources (/node_modules/generator-ramlang/lib/methods.js:190:28)
    at Object.module.exports.generate (/node_modules/generator-ramlang/lib/methods.js:226:26)
    at Object.module.exports.generate (/node_modules/generator-ramlang/lib/service.js:25:37)
    at Generator.<anonymous> (/node_modules/generator-ramlang/app/index.js:411:39)
    at Array.forEach (native)
    at Generator.generate (/node_modules/generator-ramlang/app/index.js:410:29)
    at/node_modules/generator-ramlang/node_modules/
```

Added a simple guard to get past this.
