### PR TITLE
Better subresource name handling. Makes subresources with hyphens work.

### DIFF
--- a/lib/methods.js
+++ b/lib/methods.js
@@ -171,7 +171,7 @@ var generateSubResource = function(ramlResource, relativeUri) {
 
   return _.template(subResourceTemplateText, {
     resource: {
-      name: ramlResource.relativeUri.replace('/', ''),
+      name: generatorUtil.toCamelCase(ramlResource.relativeUri.replace('/', ''), true),
       description: documentation.formatDescription(ramlResource.description, true),
       methods: generateMethods(ramlResource, relativeUri)
     }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -32,7 +32,7 @@ module.exports.readFileAsString = function(filePath) {
  * @returns {String}
  */
 module.exports.toCamelCase = function(str, startWithCapital) {
-  return inflect.camelize(str.trim().replace(/ /g, '_'), !startWithCapital);
+  return inflect.camelize(str.trim().replace(/ /g, '_').replace(/-/g, '_'), !startWithCapital);
 };
 
 /**


### PR DESCRIPTION
When using a subresource with hyphens in it, the generator produced invalid javascript. Take for instance:

```
/resource:
  /resource-with-hyphen:
    get:
      queryParameters:
        attribute:
          type: string         
```

It will attempt to create:

```
ResourceApi.Resource-with-hyphen
```

which is not a valid JS object name because of the dash. This pull request will get rid of the dash and use the camelCase version of the sub resource name yielding an object that looks like:

```
ResourceApi.ResourceWithHyphen
```
