### PR TITLE
Improve subresource method naming

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -109,7 +109,7 @@ module.exports.formatResourceDisplayName = function(ramlResource) {
  */
 module.exports.cleanSubMethodName = function(uri, startWithCapital) {
   if (uri) {
-    var cleanedName = uri.replace(/[/]|([{]\w*[}])/ig, '');
+    var cleanedName = uri.replace(/\//g, '-').replace(/([{]\w*[}])/ig, '');
     return this.toCamelCase(cleanedName, startWithCapital);
   }
 };


### PR DESCRIPTION
Previously, if you had a resource like this:

/hello/world-today/spartans-rule

The generator will generate an API that looks like this: (Notice spartans is lowercase)

```
.factory('HelloApi', ['Api', function(Api) {
  return {
    WorldTodayspartansRule: {
      post: function(entity) {
        return Api.post('/hello/world-today/spartans-rule', entity);
      }
    }
}
```

This change will improve the generated API by camel casing the method name appropriately to:  (Notice the "S" in spartans is upcase)

```
.factory('HelloApi', ['Api', function(Api) {
  return {
    WorldTodaySpartansRule: {
      post: function(entity) {
        return Api.post('/hello/world-today/spartans-rule', entity);
      }
    }
}
```
